### PR TITLE
fix: package finding for base dependencies

### DIFF
--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Update apt-get repo and cache
+  apt: update_cache=yes force_apt_get=yes cache_valid_time=3600
+
 - name: Install base dependencies
   package:
     name: "{{ item }}"


### PR DESCRIPTION
Hey, 

when I try to install it on a fresh way it doesn't find the `jq`package.

Here is my output log:

```console
vagrant provision        
==> consul-nomad-node1: Running provisioner: ansible...
Vagrant has automatically selected the compatibility mode '2.0'
according to the Ansible version installed (2.9.6).

Alternatively, the compatibility mode can be specified in your Vagrantfile:
https://www.vagrantup.com/docs/provisioning/ansible_common.html#compatibility_mode

==> consul-nomad-node1: Vagrant has detected a host range pattern in the `groups` option.
==> consul-nomad-node1: Vagrant doesn't fully check the validity of these parameters!
==> consul-nomad-node1: 
==> consul-nomad-node1: Please check https://docs.ansible.com/ansible/intro_inventory.html#hosts-and-groups
==> consul-nomad-node1: for more information.
    consul-nomad-node1: Running ansible-playbook...

PLAY [consul_nomad] ************************************************************

TASK [base : Install base dependencies] ****************************************
ok: [consul-nomad-node1] => (item=curl)
ok: [consul-nomad-node1] => (item=dnsutils)
failed: [consul-nomad-node1] (item=jq) => changed=false 
  ansible_loop_var: item
  item: jq
  msg: No package matching 'jq' is available
changed: [consul-nomad-node1] => (item=unzip)

PLAY RECAP *********************************************************************
consul-nomad-node1         : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```

After adding the apt module and updating the os cache it works as excepted.

Signed-off-by: solidnerd <niclas@mietz.io>