### PR TITLE
fix: nomad - Copy example jobs config

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Click "Run" to deploy the job to the Nomad cluster.
 If you prefer to run the demos from the command line you can use `vagrant ssh` to deploy them directly from the VM. As the files are copied to the vagrant user's home directory on all instances, the node number doesn't matter, e.g.:
 
 ```sh
-vagrant ssh consul-nomad-node1 -c 'nomad job run ~/hello-world-docker.nomad'
+vagrant ssh consul-nomad-node1 -c 'nomad job run ~/nomad_jobs/hello-world-docker.nomad'
 ```
 
 #### Collecting application metrics with Prometheus

--- a/playbook.yml
+++ b/playbook.yml
@@ -31,4 +31,4 @@
 - hosts: localhost
   tasks:
     - name: Run all jobs on Nomad # noqa 301
-      command: vagrant ssh consul-nomad-node1 -c 'for job in *.nomad; do nomad job run "$job"; done'
+      command: vagrant ssh consul-nomad-node1 -c 'for job in nomad_jobs/*.nomad; do nomad job run "$job"; done'

--- a/roles/nomad/tasks/main.yml
+++ b/roles/nomad/tasks/main.yml
@@ -34,10 +34,18 @@
     dest: "/etc/nomad.d/nomad.hcl"
     mode: 0644
 
+- name: Create jobs directory
+  file:
+    path: "/home/{{ ansible_ssh_user }}/nomad_jobs"
+    state: directory
+    owner: "{{ ansible_ssh_user }}"
+    group: "{{ ansible_ssh_user }}"
+    mode: 0755
+
 - name: Copy example jobs config
   copy:
     src: "{{ item }}"
-    dest: "/home/{{ ansible_ssh_user }}/{{ item }}"
+    dest: "/home/{{ ansible_ssh_user }}/nomad_jobs/{{ item | basename }}"
     owner: "{{ ansible_ssh_user }}"
     group: "{{ ansible_ssh_user }}"
     mode: 0644


### PR DESCRIPTION
This will fix a problem with copying or local examples from the playbook dir to vagrant guest.

I got the following error:

```console
TASK [nomad : Copy example jobs config] ****************************************
failed: [consul-nomad-node1] (item=/Users/nmietz/develop/personal/nomad-demo/nomad_jobs/hello-world-java.nomad) => changed=false
  ansible_loop_var: item
  checksum: 95c77e14ab45e71cf2072e5e3b3146cf212cf6ae
  item: /Users/nmietz/develop/personal/nomad-demo/nomad_jobs/hello-world-java.nomad
  msg: Destination directory /home/vagrant/Users/nmietz/develop/personal/nomad-demo/nomad_jobs does not exist
failed: [consul-nomad-node1] (item=/Users/nmietz/develop/personal/nomad-demo/nomad_jobs/hello-world-docker.nomad) => changed=false
  ansible_loop_var: item
  checksum: cefefddf6b40ed434d398c6f9e79b42c88a23e0b
  item: /Users/nmietz/develop/personal/nomad-demo/nomad_jobs/hello-world-docker.nomad
  msg: Destination directory /home/vagrant/Users/nmietz/develop/personal/nomad-demo/nomad_jobs does not exist
failed: [consul-nomad-node1] (item=/Users/nmietz/develop/personal/nomad-demo/nomad_jobs/prometheus.nomad) => changed=false
  ansible_loop_var: item
  checksum: ef28a9dcc5185df65348b472ec2aad4b33771dbc
  item: /Users/nmietz/develop/personal/nomad-demo/nomad_jobs/prometheus.nomad
  msg: Destination directory /home/vagrant/Users/nmietz/develop/personal/nomad-demo/nomad_jobs does not exist
```

So to solve this I created a directory under `~/nomad_jobs` and copied only with the filename so that he doesn't need the local path.

Signed-off-by: solidnerd <niclas@mietz.io>