### PR TITLE
Disable serial ports for Windows WSL compatibility

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,6 +21,10 @@ Vagrant.configure(2) do |config|
       # Increase memory for Virtualbox
       node.vm.provider "virtualbox" do |vb|
         vb.memory = "1024"
+        vb.customize [ "modifyvm", :id, "--uartmode1", "disconnected" ]
+        vb.customize [ "modifyvm", :id, "--uartmode2", "disconnected" ]
+        vb.customize [ "modifyvm", :id, "--uartmode3", "disconnected" ]
+        vb.customize [ "modifyvm", :id, "--uartmode4", "disconnected" ]
       end
     end
   end
@@ -29,6 +33,12 @@ Vagrant.configure(2) do |config|
     node_ip_address = "#{get_ip(0)}"
     lb.vm.network "private_network", ip: node_ip_address
     lb.vm.hostname = "loadbalancer"
+    lb.vm.provider "virtualbox" do |vb|
+      vb.customize [ "modifyvm", :id, "--uartmode1", "disconnected" ]
+      vb.customize [ "modifyvm", :id, "--uartmode2", "disconnected" ]
+      vb.customize [ "modifyvm", :id, "--uartmode3", "disconnected" ]
+      vb.customize [ "modifyvm", :id, "--uartmode4", "disconnected" ]
+    end
   end
 
   config.vm.provision "ansible", type: "ansible", run: "never" do |ansible|


### PR DESCRIPTION
Disconnecting the serial ports on the VMs avoids errors when starting the VMs from WSL inside a Windows host.   The workaround comes from https://stackoverflow.com/a/45774147/4271408 and https://stackoverflow.com/a/59978061/4271408 and references this issue on the main Vagrant repository https://github.com/hashicorp/vagrant/issues/8604.